### PR TITLE
Revert "Esmf makefile update for NEMS"

### DIFF
--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -36,7 +36,7 @@ else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","pgi" "datarmor_pgi" "datarmor_p
 # intel
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","theia" "Intel"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
-else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_phase2" "wcoss_cray" "wcoss_dell_p3"))
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_phase2" "wcoss_cray"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","intel" "datarmor_intel" "datarmor_intel_debug"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian


### PR DESCRIPTION
Reverts ajhenrique/WW3#1: this pull request reintroduced fPIC flag and references to libso that had been removed with a previous commit. The change to makefile under esmf to include dell_p3 as an option will be added onto a clean copy of the branch.