### PR TITLE
w3adc: Update to allow multiple switches on single line

### DIFF
--- a/model/aux/w3adc.f
+++ b/model/aux/w3adc.f
@@ -3,8 +3,11 @@ C/
 C/                  +-----------------------------------+
 C/                  |           H. L. Tolman            |
 C/                  |                        FORTRAN 77 |
-C/                  | Last update :         05-Jan-2001 |
+C/                  | Last update :         03-Feb-2020 |
 C/                  +-----------------------------------+
+C/
+C/    03-Feb-2020 : Added ability to process multiple   ( version 7.00 )
+C/                  switches on a single line. Chris Bunney, UKMO
 C/
 C/    Version to preprocess FORTRAN 90 free format code.
 C/
@@ -77,7 +80,11 @@ C
 C  7. Remarks :
 C
 C     - Switches are case-sensitive
-C     - Switch in code has to be followed by space.
+C     - Switch in code has to be followed by space, forward slash (/) or
+C       exclamation mark (!)
+C     - Multiple switches can appear on a single line, seperated by 
+C       a forward slash or exclamation mark. In this case all switches
+C       need to be present in switch file for the line to be included.
 C     - Switches can be used in include files, since include files are
 C       are pre-processed before the actual file is processed. Includes
 C       in include files, however, are not accepted.
@@ -253,30 +260,52 @@ C
       FLKEEP = .TRUE.
       FLSWTC = .FALSE.
 *
-      IF ( NEWLNE(1:2).EQ.'!/' ) THEN
+      ! Rewrite for multiple switches on single line
+      ! Chris Bunney, Feb 2020.
+      DO 140
+        IF(NEWLNE(1:2) .EQ. '!/') THEN
+          ! Potential switch
+          FLSWTC = .FALSE.
           FLKEEP = .FALSE.
+*
+          ! Check if just a comment
           IF ( NEWLNE(3:3) .EQ. ' ' ) THEN
-              FLSWTC = .TRUE.
-              GOTO 141
-            ENDIF
-          DO 140, I=1, NSWTCH
-            SW0    = SWITCH(I)
-            J      = LS(I)
-            IF ( NEWLNE( 3 :2+J) .EQ. SW0(1:J) ) THEN
-                IF (  NEWLNE(3+J:3+J) .EQ. ' ' ) THEN
-                    NEWLNE(1:MMLOUT) = NEWLNE(3+J:MMLOUT+3+J-1)
-                    FLSWTC = .TRUE.
-                    GOTO 141
-                  ENDIF
-                IF (  NEWLNE(3+J:3+J) .EQ. '/' ) THEN
-                    NEWLNE(1:MMLOUT) = NEWLNE(4+J:MMLOUT+4+J-1)
-                    FLSWTC = .TRUE.
-                    GOTO 141
-                  ENDIF
+            FLSWTC = .TRUE.
+            GOTO 142  ! Assumes no more switches
+          ENDIF
+*
+          ! Check if is an activated switch:
+          DO 141, I=1, NSWTCH
+            SW0 = SWITCH(I)
+            J = LS(I)
+            IF(NEWLNE(3:2+J) .EQ. SW0(1:J)) THEN
+*
+              IF(NEWLNE(3+J:3+J) .EQ. ' ' .OR.        
+     &             NEWLNE(3+J:3+J) .EQ. '!') THEN
+                NEWLNE(1:MMLOUT) = NEWLNE(3+J:MMLOUT+3+J-1)
+                FLSWTC = .TRUE.
+                GOTO 140
               ENDIF
-  140       CONTINUE
-  141     CONTINUE
+*
+              IF(NEWLNE(3+J:3+J) .EQ. '/' ) THEN
+                NEWLNE(1:MMLOUT) = NEWLNE(4+J:MMLOUT+4+J-1)
+                FLSWTC = .TRUE.
+                GOTO 140
+              ENDIF
+*
+            ENDIF
+ 141      CONTINUE ! ENDDO
+*
+          ! No match found for switch - don't include line
+          FLSWTC = .FALSE.
+          GOTO 142
+        ELSE
+          ! No more switches, break out of do loop
+          GOTO 142
         ENDIF
+* 
+ 140  CONTINUE ! ENDDO
+ 142  CONTINUE ! ESCAPE
 *
 * keep line ...
 *
@@ -368,30 +397,52 @@ C
       FLKEEP = .TRUE.
       FLSWTC = .FALSE.
 *
-      IF ( NEWLNE(1:2).EQ.'!/' ) THEN
+      ! Rewrite for multiple switches on single line
+      ! Chris Bunney, Feb 2020.
+      DO 310
+        IF(NEWLNE(1:2) .EQ. '!/') THEN
+          ! Potential switch
+          FLSWTC = .FALSE.
           FLKEEP = .FALSE.
+*
+          ! Check if just a comment
           IF ( NEWLNE(3:3) .EQ. ' ' ) THEN
-              FLSWTC = .TRUE.
-              GOTO 311
-            ENDIF
-          DO 310, I=1, NSWTCH
-            SW0    = SWITCH(I)
-            J      = LS(I)
-            IF ( NEWLNE( 3 :2+J) .EQ. SW0(1:J) ) THEN
-                IF (  NEWLNE(3+J:3+J) .EQ. ' ' ) THEN
-                    NEWLNE(1:MMLOUT) = NEWLNE(3+J:MMLOUT+3+J-1)
-                    FLSWTC = .TRUE.
-                    GOTO 311
-                  ENDIF
-                IF (  NEWLNE(3+J:3+J) .EQ. '/' ) THEN
-                    NEWLNE(1:MMLOUT) = NEWLNE(4+J:MMLOUT+4+J-1)
-                    FLSWTC = .TRUE.
-                    GOTO 311
-                  ENDIF
+            FLSWTC = .TRUE.
+            GOTO 312  ! Assumes no more switches
+          ENDIF
+*
+          ! Check if is an activated switch:
+          DO 311, I=1, NSWTCH
+            SW0 = SWITCH(I)
+            J = LS(I)
+            IF(NEWLNE(3:2+J) .EQ. SW0(1:J)) THEN
+*
+              IF(NEWLNE(3+J:3+J) .EQ. ' ' .OR.        
+     &             NEWLNE(3+J:3+J) .EQ. '!') THEN
+                NEWLNE(1:MMLOUT) = NEWLNE(3+J:MMLOUT+3+J-1)
+                FLSWTC = .TRUE.
+                GOTO 310
               ENDIF
-  310       CONTINUE
-  311     CONTINUE
+*
+              IF(NEWLNE(3+J:3+J) .EQ. '/' ) THEN
+                NEWLNE(1:MMLOUT) = NEWLNE(4+J:MMLOUT+4+J-1)
+                FLSWTC = .TRUE.
+                GOTO 310
+              ENDIF
+*
+            ENDIF
+ 311      CONTINUE ! ENDDO
+*
+          ! No match found for switch - don't include line
+          FLSWTC = .FALSE.
+          GOTO 312
+        ELSE
+          ! No more switches, break out of do loop
+          GOTO 312
         ENDIF
+* 
+ 310  CONTINUE ! ENDDO
+ 312  CONTINUE ! ESCAPE
 *
 * include ???
 *


### PR DESCRIPTION
There are several cases in the WW3 code base where it would be advantageous for the pre-processor (w3adc) to allow multiple switches on one line. I.e. to only include a line of code if all switches for that line are specified in the switch file.

This change updates **w3adc.f** to handle multiple switches on a single line both in the include files (if any) and the primary source file.

Each switch should start with the usual `!/` and be chained together with no spaces between, or optionally an extra `/`, e.g. the following lines are equivalent and will only be activated if both the `OMPH` and `T1` switches are set  in the `switch` file:
```
    !/OMPH!/T1     <some code>
    !/OMPH/!/T1/   <some code>
```

The switch section is assumed to be complete when no more `!/` characters can be read (or `!/` is followed by a space).

Any amount of switches can be added to a line (up to the maximum line length of 143 characters defined in `w3adc`).